### PR TITLE
CLN:중복된 commons-fileupload dependency 삭제

### DIFF
--- a/SejongTrack/pom.xml
+++ b/SejongTrack/pom.xml
@@ -215,12 +215,6 @@
     </dependency>
 
     <dependency>
-      <groupId>commons-fileupload</groupId>
-      <artifactId>commons-fileupload</artifactId>
-      <version>1.3.1</version>
-    </dependency>
-
-    <dependency>
       <groupId>org.imgscalr</groupId>
       <artifactId>imgscalr-lib</artifactId>
       <version>4.2</version>


### PR DESCRIPTION
commons-fileupload  dependency가 1.3.1, 1.4 두버젼이 있어서 github security alert 발생 하여 1.3.1 버젼 삭제