### PR TITLE
[EHN,CLN]멤버 정보 수정 페이지

### DIFF
--- a/src/main/java/kr/ac/sejong/config/SpringSecurityConfig.java
+++ b/src/main/java/kr/ac/sejong/config/SpringSecurityConfig.java
@@ -2,24 +2,18 @@
 
 package kr.ac.sejong.config;
 
-//import kr.ac.sejong.filter.AjaxSessionTimeoutFilter;
-
 import kr.ac.sejong.handler.CustomLoginSuccessHandler;
 import kr.ac.sejong.handler.CustomLogoutSuccessHandler;
 import kr.ac.sejong.service.CustomAuthenticationProvider;
 import lombok.extern.java.Log;
-import org.springframework.boot.web.servlet.ServletListenerRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-import org.springframework.security.core.session.SessionRegistry;
-import org.springframework.security.core.session.SessionRegistryImpl;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.web.session.HttpSessionEventPublisher;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 import javax.inject.Inject;
@@ -38,19 +32,11 @@ public class SpringSecurityConfig extends WebSecurityConfigurerAdapter {
     @Inject
     CustomLogoutSuccessHandler logoutSuccessHandler;
 
-//    @Inject
-//    SessionFilter sessionFilter;
-
     /* Password Encoder 등록 */
     @Bean
     public PasswordEncoder passwordEncoder() {
         return PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
-
-//    @Autowired
-//    public void configureGlobal(AuthenticationManagerBuilder auth) throws Exception {
-//
-//    }
 
     /* Security 제외 패턴 */
     @Override
@@ -64,9 +50,9 @@ public class SpringSecurityConfig extends WebSecurityConfigurerAdapter {
     protected void configure(HttpSecurity http) throws Exception {
         http.authorizeRequests()
                 /*페이지 권한 설정*/
-                .antMatchers("/visitor/**","/student/**", "/uploadForm/**", "/trackJudge/**").hasAnyAuthority("ADMIN","PRO", "STUDENT")
+                .antMatchers("/visitor/**", "/student/**", "/uploadForm/**", "/trackJudge/**").hasAnyAuthority("ADMIN", "PRO", "STUDENT")
                 .antMatchers("/trackrule/**").hasAnyAuthority("ADMIN", "PRO")
-                .antMatchers("/modifyView/**","/memberModify/**").authenticated()
+                .antMatchers("/modifyView/**", "/memberModify/**").authenticated()
                 .antMatchers("/**").permitAll()
 
                 .and() //로그인 설정
@@ -76,16 +62,16 @@ public class SpringSecurityConfig extends WebSecurityConfigurerAdapter {
                 .usernameParameter("id")
                 .passwordParameter("password")
                 .successHandler(loginSuccessHandler) /* 로그인 성공시 핸들러 */
-                                                     /* 핸들러가 있을 땐 url을 redirect하는 메소드는 실행 안하나봄 */
                 .failureUrl("/loginView") /*로그인 실패시 뷰*/
                 .permitAll() /* 모두 오픈 */
 
                 .and() //로그아웃 설정
                 .logout()
                 .logoutRequestMatcher(new AntPathRequestMatcher("/memberLogout"))
-                .invalidateHttpSession(true)
-                .deleteCookies("JSESSIONID")
                 .logoutSuccessHandler(logoutSuccessHandler)
+                .deleteCookies("JSESSIONID")
+                .invalidateHttpSession(true)
+
 
                 .and()
                 .exceptionHandling() /*예외처리*/
@@ -97,11 +83,11 @@ public class SpringSecurityConfig extends WebSecurityConfigurerAdapter {
         http.sessionManagement()
                 .maximumSessions(1)/*최대 허용 가능 중복 세션 수*/
                 .maxSessionsPreventsLogin(false) /*true: 로그인이 이미 되어있는 경우 중복 로그인이 안된다,false면 두번째 로그인 되고, 첫번째가 세션만료된다*/
-                .expiredUrl("/memberExpired") /*
-                                                *중복 로그인이 일어낫을 경우 선 로그인 유저가 이동할 페이지
-                                                *invalidSessionUrl : 세션만료됐을 경우 로그아웃시키는 url. (우선순위)
-                                                *expiredUrl : 강제로그아웃되고, url로 이동.
-                                               */
+                .expiredUrl("/memberExpired")/*
+                                             *중복 로그인이 일어낫을 경우 선 로그인 유저가 이동할 페이지
+                                             *invalidSessionUrl : 세션만료됐을 경우 로그아웃시키는 url페이지. (우선순위)
+                                             *expiredUrl : 강제로그아웃되고, url로 이동.
+                                             */
 
                 .and()
                 .sessionFixation().newSession(); /* 사용자 로그인 때마다 새로운 세션을 생성한다 */

--- a/src/main/java/kr/ac/sejong/domain/CustomUserDetails.java
+++ b/src/main/java/kr/ac/sejong/domain/CustomUserDetails.java
@@ -32,7 +32,7 @@ public class CustomUserDetails implements UserDetails {
     private String name;
     private String email;
 
-    private List<GrantedAuthority> authorities; //세션을 위한 객제인듯. 따라서 필드는 id, pw만 쓰겠음.
+    private List<GrantedAuthority> authorities; //세션을 위한 객제인듯.
 
     public CustomUserDetails(String id, String password, String name, String email,
                              List<GrantedAuthority> authorities) {
@@ -43,7 +43,6 @@ public class CustomUserDetails implements UserDetails {
         this.email = email;
         this.authorities = authorities;
     }
-
 
     /** db에서 꺼내와서 이 유저가 가질 권한 add해줘서 리턴 */
     @Override

--- a/src/main/java/kr/ac/sejong/domain/MemberRole.java
+++ b/src/main/java/kr/ac/sejong/domain/MemberRole.java
@@ -32,6 +32,7 @@ public class MemberRole implements GrantedAuthority, Serializable {
     }
 
     public MemberRole(){}
+
     @Builder
     public MemberRole(Long roleId, MemberRoleEnum roleEnum, Member member) {
         this.roleId = roleId;

--- a/src/main/java/kr/ac/sejong/handler/CustomLoginSuccessHandler.java
+++ b/src/main/java/kr/ac/sejong/handler/CustomLoginSuccessHandler.java
@@ -21,12 +21,11 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import java.io.IOException;
 import java.util.Date;
-import java.util.Enumeration;
 
 @Log
 @Component("loginSuccessHandler")
 public class CustomLoginSuccessHandler implements AuthenticationSuccessHandler {
-    private static int TIME = 10; // 30분
+    private static int TIME = 30*60; // 30분
 
     private RequestCache requestCache = new HttpSessionRequestCache();
     private RedirectStrategy redirectStrategy = new DefaultRedirectStrategy();
@@ -43,14 +42,6 @@ public class CustomLoginSuccessHandler implements AuthenticationSuccessHandler {
 
         //세션 지속시간 설정 : 세션의 기본 객체가 사용될 때마다 세션의 최근 접근 시간은 갱신된다.
         request.getSession().setMaxInactiveInterval(TIME);
-//        request.getSession().setAttribute("isSession","yes");
-//        log.info("login session 궁금하지?");
-//        Enumeration e = request.getSession().getAttributeNames();
-//        int i=0;
-//        while( e.hasMoreElements()){
-//            String t_name = e.nextElement().toString();
-//            log.info("| "+ ++i + " |"+ t_name+":"+request.getSession().getAttribute(t_name));
-//        }
 
         //로그인 한 날짜 기록
         updateLoginDate(auth);
@@ -79,12 +70,12 @@ public class CustomLoginSuccessHandler implements AuthenticationSuccessHandler {
         session.removeAttribute(WebAttributes.AUTHENTICATION_EXCEPTION);
     }
 
-    protected void updateLoginDate(Authentication auth){
-        log.info("authToken & getPrincipal() : " + auth.getPrincipal()); /** auth.getName()은 auth의 Principal의 종류를 매칭한 후
-                                                                                * (이 경우 CustomUserDetails)
-                                                                                * 그 객체의 name정보를 가져오는 것 */
+    protected void updateLoginDate(Authentication auth) {
+        /** auth.getName()은 auth의 Principal의 종류를 매칭한 후
+         * (이 경우 CustomUserDetails)
+         * 그 객체의 name정보를 가져오는 것 */
         String user_id = ((CustomUserDetails) auth.getPrincipal()).getId();
-        log.info("authToken & cast to CustomUserDetials : " + user_id);
+
         Member member = memberRepository.findById(user_id).get();
         member.setLogindate(new Date());
         memberRepository.save(member);

--- a/src/main/java/kr/ac/sejong/handler/CustomLogoutSuccessHandler.java
+++ b/src/main/java/kr/ac/sejong/handler/CustomLogoutSuccessHandler.java
@@ -8,27 +8,31 @@ import org.springframework.stereotype.Component;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 import java.io.IOException;
-import java.util.Enumeration;
 
 @Log
 @Component("logoutSuccessHandler")
 public class CustomLogoutSuccessHandler implements LogoutSuccessHandler {
 
+
     @Override
     public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response,
                                 Authentication authentication) throws IOException, ServletException {
-
-        log.info("onLogoutSuccess - authentication : "+ authentication.toString()); /*로그아웃 하는*/
-
-        if (authentication != null && authentication.getDetails() != null) {
-            try {
-                request.getSession().invalidate();
-            } catch (Exception exc) {
-                exc.printStackTrace();
+        HttpSession session = request.getSession();
+        try {
+            if (authentication != null && authentication.getDetails() != null) {
+                try {
+                    request.getSession().invalidate();
+                } catch (Exception exc) {
+                    exc.printStackTrace();
+                }
             }
+            response.setStatus(HttpServletResponse.SC_OK);
+            response.sendRedirect("/");
+        } catch (NullPointerException e) {
+            e.printStackTrace();
+            session.setAttribute("sessionState", "timeout");
         }
-        response.setStatus(HttpServletResponse.SC_OK);
-        response.sendRedirect("/");
     }
 }

--- a/src/main/java/kr/ac/sejong/listener/CustomHttpSessionEventPublisher.java
+++ b/src/main/java/kr/ac/sejong/listener/CustomHttpSessionEventPublisher.java
@@ -36,8 +36,6 @@ public class CustomHttpSessionEventPublisher extends HttpSessionEventPublisher {
 
     @Override
     public void sessionDestroyed(HttpSessionEvent event) {    //문제점 : timeout에 의한 로그아웃이 자동기록이 안됨.
-        log.info("eventPublisher - sessionDestroyed  ");
-
         // session
         HttpSession session = event.getSession();
 
@@ -57,7 +55,5 @@ public class CustomHttpSessionEventPublisher extends HttpSessionEventPublisher {
             member.setLogoutdate(new Date());
             memberRepository.save(member);
         }
-
-
     }
 }

--- a/src/main/java/kr/ac/sejong/service/CustomAuthenticationProvider.java
+++ b/src/main/java/kr/ac/sejong/service/CustomAuthenticationProvider.java
@@ -2,7 +2,6 @@ package kr.ac.sejong.service;
 
 import kr.ac.sejong.domain.CustomUserDetails;
 import lombok.extern.java.Log;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -34,7 +33,7 @@ public class CustomAuthenticationProvider implements AuthenticationProvider {
     @Override
     public Authentication authenticate(Authentication authentication) throws AuthenticationException {
         /* Authentication을 상속받는 클래스. principal, credential, authorities 제공 */
-        UsernamePasswordAuthenticationToken authToken = (UsernamePasswordAuthenticationToken) authentication; //유저가 입력한 정보를 이이디비번으로만든다.(로그인한 유저아이디비번정보를담는다)
+        UsernamePasswordAuthenticationToken authToken = (UsernamePasswordAuthenticationToken) authentication; //로그인한 유저아이디비번정보를담는다.
         CustomUserDetails userInfo = null;
 
         /* 회원정보 로드, 패스워드 인증 로직 */
@@ -52,7 +51,7 @@ public class CustomAuthenticationProvider implements AuthenticationProvider {
         }
 
         List<GrantedAuthority> authorities = (List<GrantedAuthority>) userInfo.getAuthorities();
-        log.info("provider - getAuthorities() : " + authorities);
+
         /* 인증처리 후 인가. 인가할 때는 비밀번호는 null로 */
         return new UsernamePasswordAuthenticationToken(userInfo, null, authorities);
     }

--- a/src/main/java/kr/ac/sejong/service/MemberService.java
+++ b/src/main/java/kr/ac/sejong/service/MemberService.java
@@ -2,12 +2,8 @@ package kr.ac.sejong.service;
 
 import kr.ac.sejong.domain.Member;
 
-import java.util.Optional;
-
 public interface MemberService {
-    public int join(Member m);
+    int join(Member m);
 
-    public Optional<Member> findMember(Member m);
-
-    public String IsMemberExist(Member m);
+    String IsMemberExist(Member m);
 }

--- a/src/main/java/kr/ac/sejong/service/MemberServiceImpl.java
+++ b/src/main/java/kr/ac/sejong/service/MemberServiceImpl.java
@@ -2,43 +2,32 @@ package kr.ac.sejong.service;
 
 import kr.ac.sejong.domain.Member;
 import kr.ac.sejong.persistence.MemberRepository;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.java.Log;
 import org.springframework.stereotype.Service;
 
 import javax.inject.Inject;
 import java.util.Optional;
 
 @Service
+@Log
 public class MemberServiceImpl implements MemberService {
-
-    private static Logger logger = LoggerFactory.getLogger(MemberServiceImpl.class);
 
     @Inject
     MemberRepository memberRepository;
 
     @Override
-    public int join(Member m){ // id 중복확인만 하고 join판단
-        //중복검사
-        if(IsMemberExist(m) == "No"){
+    public int join(Member m) {
+        if (IsMemberExist(m) == "No") { //중복검사
             memberRepository.save(m);
             return 1;
-        }
-        else{
+        } else {
             return -1;
         }
     }
 
     @Override
-    public Optional<Member> findMember(Member m){
-
-        return memberRepository.findById(m.getId());
-    }
-
-    @Override
     public String IsMemberExist(Member m) {
         Optional<Member> maybeMember = memberRepository.findById(m.getId());
-        logger.info("maybeMember.isPresent() : "+ maybeMember.isPresent());
         return (maybeMember.isPresent()) ? "Yes" : "No";
     }
 

--- a/src/main/webapp/WEB-INF/views/exception.jsp
+++ b/src/main/webapp/WEB-INF/views/exception.jsp
@@ -57,6 +57,5 @@
 </div>
 <%-- ./wrapper --%>
 
-<%@ include file="include/plugins.jsp" %>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/views/include/head.jsp
+++ b/src/main/webapp/WEB-INF/views/include/head.jsp
@@ -167,10 +167,7 @@
     </style>
 
     <%@ include file="../include/plugins.jsp" %>
-    <c:set var="sessionChk" value="${isUser}"/>
-    <%--<sec:authorize access="isAuthenticated()">--%>
-        <%--<c:set var="isAuth" value="yes"/>--%>
-    <%--</sec:authorize>--%>
+
     <script type="text/javascript">
 
         function go(text) {
@@ -178,14 +175,5 @@
             target: _self;
         }
 
-        $(document).ready(function (){
-
-            console.log('sessionChk : ' + '<c:out value="${sessionChk}"/>');
-
-            if ('<c:out value="${sessionChk}"/>' == 'no')
-            {
-                alert('세션이 만료되었습니다. 로그인 후 이용하세요.');
-            }
-        });
     </script>
 </head>

--- a/src/main/webapp/WEB-INF/views/member/modify.jsp
+++ b/src/main/webapp/WEB-INF/views/member/modify.jsp
@@ -15,40 +15,35 @@
     <div class="register-box-body">
         <p class="login-box-msg">profile</p>
 
-        <form id="joinForm" action="/memberJoin" method="post" onsubmit="return totalCheck()">
-            <sec:authorize access="isAuthenticated()">
-                Id
+        <form id="joinForm" action="/modifyMemberInfo" method="post">
+            Id
             <div class="form-group has-feedback">
-                <input type="text" class="form-control" name="id" disabled value=<sec:authentication property="principal.id"/>>
+                <input type="text" class="form-control" name="id" readonly value=<sec:authentication
+                        property="principal.id"/>>
                 <span class="glyphicon glyphicon-user form-control-feedback"></span>
             </div>
-                Password
+            Password
             <div class="form-group has-feedback">
-                <button>modify password</button>
+                <input type="button" value="modify password" onclick="showPopup_pw()"/>
                 <span class="glyphicon glyphicon-user form-control-feedback"></span>
             </div>
-                Name
+            Name
             <div class="form-group has-feedback">
-                <input type="text" class="form-control" name="name"  value=<sec:authentication property="principal.name"/>>
+                <input type="text" class="form-control" name="name" value=<sec:authentication
+                        property="principal.name"/>>
                 <span class="glyphicon glyphicon-user form-control-feedback"></span>
             </div>
-                Email
+            Email
             <div class="form-group has-feedback">
-                <input type="email" class="form-control" name="email"  value=<sec:authentication property="principal.email"/>>
+                <input type="email" class="form-control" name="email" value=<sec:authentication
+                    property="principal.email"/>>
                 <span class="glyphicon glyphicon-envelope form-control-feedback"></span>
             </div>
-                <br>Please enter a password to modify the information.
+            <br>Please enter a password to modify the information.
             <div class="form-group has-feedback">
                 <input type="password" class="form-control" name="password" required placeholder="password">
                 <span class="glyphicon glyphicon-lock form-control-feedback"></span>
             </div>
-
-            <div class="form-group has-feedback">
-                <input type="passwordCheck" class="form-control" name="password" required placeholder="retype password">
-                <span class="glyphicon glyphicon-lock form-control-feedback"></span>
-            </div>
-
-            </sec:authorize>
             <div class="row">
                 <div class="col-xs-8">
                     <div class="checkbox icheck">
@@ -73,6 +68,10 @@
 </html>
 
 <script type="text/javascript">
+
+    function showPopup_pw() {
+        window.open("/popupPwModify", "비밀번호 변경", "width=400,height=300, left=100, top=100, scrollbars=no");
+    }
 
     $('input').iCheck({ //AdminLTE 회원가입 테마 jquery
         checkboxClass: 'icheckbox_square-blue',

--- a/src/main/webapp/WEB-INF/views/member/pw_popup.jsp
+++ b/src/main/webapp/WEB-INF/views/member/pw_popup.jsp
@@ -1,0 +1,70 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="sec" uri="http://www.springframework.org/security/tags" %>
+<c:set var="userId" value='principal.id'/>
+
+<!DOCTYPE html>
+<html>
+<%@ include file="../include/head.jsp" %>
+
+<body>
+
+<form id="joinForm" action="/modifyPw" method="post" onsubmit="return totalCheck()">
+        <div class="form-group has-feedback">
+            기존 비밀번호
+            <input type="password" class="form-control" name="password" required placeholder="original password">
+            <span class="glyphicon glyphicon-lock form-control-feedback"></span>
+        </div>
+        <div class="form-group has-feedback">
+            새 비밀번호
+            <input type="password" class="form-control" name="newPw" required placeholder="new password">
+            <span class="glyphicon glyphicon-lock form-control-feedback"></span>
+        </div>
+        <div class="form-group has-feedback">
+            재입력
+            <input type="password" class="form-control" name="newPwRe" required placeholder="retype new password">
+            <span class="glyphicon glyphicon-lock form-control-feedback"></span>
+            <div class="col-xs-8"><span id="pwCheckRes"></span></div>
+        </div>
+    <div class="col-xs-5">
+        <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
+        <input type="hidden" name="id" value="<sec:authentication property='principal.id'/>"/>
+        <button type="submit" class="btn btn-primary btn-block btn-flat">change password</button>
+    </div>
+</form>
+
+</body>
+</html>
+<script type="text/javascript">
+    var psRes=false;
+
+    //비밀번호 재확인 체킹
+    function pwCorrect() {
+
+        $("input[name=newPw]").keyup(function () {
+            if ($("input[name=newPw]").val() == $("input[name=newPwRe]").val()) {
+                $("#pwCheckRes").html("비밀번호가 일치합니다.");
+                pwRes = true;
+            } else {
+                $("#pwCheckRes").html("비밀번호가 일치하지 않습니다.");
+                pwRes = false;
+            }
+        });
+
+        $("input[name=newPwRe]").keyup(function () {
+            if ($("input[name=newPw]").val() == $("input[name=newPwRe]").val()) {
+                $("#pwCheckRes").html("비밀번호가 일치합니다.");
+                pwRes = true;
+            } else {
+                $("#pwCheckRes").html("비밀번호가 일치하지 않습니다.");
+                pwRes = false;
+            }
+        });
+    }
+
+    pwCorrect();
+
+    function totalCheck(){
+        return pwRes;
+    }
+</script>

--- a/src/main/webapp/WEB-INF/views/trackAll.jsp
+++ b/src/main/webapp/WEB-INF/views/trackAll.jsp
@@ -76,7 +76,6 @@
 </div>
 <%-- ./wrapper --%>
 
-<%@ include file="include/plugins.jsp" %>
 </body>
 </html>
 

--- a/src/main/webapp/WEB-INF/views/trackJudge.jsp
+++ b/src/main/webapp/WEB-INF/views/trackJudge.jsp
@@ -306,7 +306,6 @@
 </div>
 <%-- ./wrapper --%>
 
-<%@ include file="include/plugins.jsp" %>
 </body>
 
 <script language="JavaScript">

--- a/src/main/webapp/WEB-INF/views/trackrule.jsp
+++ b/src/main/webapp/WEB-INF/views/trackrule.jsp
@@ -168,7 +168,6 @@
 <%-- ./wrapper --%>
 <script src="/track_js/rule.js"></script>
 
-<%@ include file="include/plugins.jsp" %>
 </body>
 
 <script language="JavaScript">

--- a/src/main/webapp/WEB-INF/views/uploadForm.jsp
+++ b/src/main/webapp/WEB-INF/views/uploadForm.jsp
@@ -129,7 +129,6 @@
 </div>
 <%-- ./wrapper --%>
 
-<%@ include file="include/plugins.jsp" %>
 </body>
 <script language="JavaScript">
     $(document).ajaxStart(function () {


### PR DESCRIPTION
- controller의 로그아웃 뷰 이동 코드 삭제

- 클래스 내 import 하지 않는 클래스 삭제

- 로그인로그아웃 이외의(main-sidebar에서 이동하는) 뷰들에서
  <%@ include file="include/plugins.jsp" %> 부분 삭제.

  (head.jsp에 이미 있는데 한번더 import해서 무한로딩표시 버그가 났었음.)

- 세션지속시간 30분으로 수정

- head.jsp : 안쓰는 js function 삭제

[EHN] 자기 정보 수정 페이지 + bug해결

- 패스워드 수정 / 패스워드 외 수정으로 나눔
  - 패스워드 수정 url-mapping "/modifyPw"
    -> 팝업창 사용.(변경 버튼 누른 후 자동으로 창 닫는걸 몰라서 안함)
  - 패스워드 외 수정 url-mapping "/modifyMemberInfo"

- 수정버튼 누르면 바로 로그아웃됨(세션삭제 후 다시 로그인해야 뷰에 수정된 정보가 보여지기 때문)

- bug : /modifyMemberInfo 에서 커맨드객체를 받을 때 id값만 null로 받아짐.
  원인 : modifyView에서 input 옵션 disabled로 돼있는 경우 컨트롤러로 넘어갈 때 값이
        null로 들어간다.
        -> disabled 대신 유저가 id값 건드리지 않을 텍스트박스를 찾아야됨.
  수정 : input 옵션인 readonly로 변경 후 정상작동

@riyenas0925 