### PR TITLE
[CLN, ENH] 트랙 판정시 이수율이 100%가 넘는 오류 수정, 이수율로 그래프 색상을 반환하는 기능 추가

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,14 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.12.1</version>
       </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+                <source>9</source>
+                <target>9</target>
+            </configuration>
+        </plugin>
     </plugins>
   </build>
 

--- a/src/main/java/kr/ac/sejong/web/dto/trackjudge/CourseStatisticDto.java
+++ b/src/main/java/kr/ac/sejong/web/dto/trackjudge/CourseStatisticDto.java
@@ -16,6 +16,7 @@ public class CourseStatisticDto {
     private List<CourseResponseDto> Courses;
     private Long sumCredit;
     private Long ruleCredit;
+    private Long minSumAndRuleCredit;
     private Double percent;
 
     @Builder
@@ -23,6 +24,12 @@ public class CourseStatisticDto {
         this.Courses = Courses;
         this.sumCredit = sumCredit;
         this.ruleCredit = ruleCredit;
-        this.percent = Double.valueOf(sumCredit) / Double.valueOf(ruleCredit) * 100.0;
+        this.minSumAndRuleCredit = Math.min(sumCredit, ruleCredit);
+
+        if(ruleCredit != 0) {
+            this.percent = Double.valueOf(this.minSumAndRuleCredit) / Double.valueOf(ruleCredit) * 100.0;
+        } else {
+            this.percent = 0.0;
+        }
     }
 }

--- a/src/test/java/kr/ac/sejong/TrackJudgeTest.java
+++ b/src/test/java/kr/ac/sejong/TrackJudgeTest.java
@@ -40,7 +40,6 @@ public class TrackJudgeTest {
     @Autowired
     private TrackCourseService trackCourseService;
 
-
     List<Course> transcriptCourses;
     List<TrackCourse> standardCourses;
 


### PR DESCRIPTION
Resolves #191 

* 응용교과 같은경우 9개중에 6개 이상 들어야 이수 이기때문에 규칙 학점보다 넘게 이수하여 이수율이 100%가 넘는 오류 발생 해결
    > 학점 총합이 규칙 학점 보다 크면 규칙 점수로 계산

* java stream을 사용한 방식이 가독성이 떨어지는것 같아서 일반적인 for문으로 변경
* pecent를 이용하여 percent에 해당하는 그래프 색상 반환
