### PR TITLE
ENH : 전체트랙 조회시 해당 대학에 존재하는 모든 CourseType을 반환하는 기능 추가

### DIFF
--- a/src/main/java/kr/ac/sejong/domain/rule/RuleCustomRepository.java
+++ b/src/main/java/kr/ac/sejong/domain/rule/RuleCustomRepository.java
@@ -5,4 +5,5 @@ import java.util.List;
 
 public interface RuleCustomRepository {
     public List<Rule> findByTrackIdAndDegreeId(Long trackId, Long degreeId);
+    public List<Rule> findByUnivIdDistinct(Long univId);
 }

--- a/src/main/java/kr/ac/sejong/domain/rule/RuleRepositoryImpl.java
+++ b/src/main/java/kr/ac/sejong/domain/rule/RuleRepositoryImpl.java
@@ -22,4 +22,14 @@ public class RuleRepositoryImpl extends QuerydslRepositorySupport implements Rul
                 .where(rule.degree.id.eq(degreeId))
                 .fetch();
     }
+
+    @Override
+    public List<Rule> findByUnivIdDistinct(Long univId) {
+        final QRule rule = QRule.rule;
+
+        return from(rule)
+                .where(rule.track.univ.id.eq(univId))
+                .distinct()
+                .fetch();
+    }
 }

--- a/src/main/java/kr/ac/sejong/domain/trackcourse/TrackCourseCustomRepository.java
+++ b/src/main/java/kr/ac/sejong/domain/trackcourse/TrackCourseCustomRepository.java
@@ -4,5 +4,5 @@ import java.util.List;
 
 public interface TrackCourseCustomRepository {
     public List<TrackCourse> findByTrackId(Long trackId);
-    public List<TrackCourse> findByUnivId(Long trackId);
+    public List<TrackCourse> findByUnivId(Long univId);
 }

--- a/src/main/java/kr/ac/sejong/service/TrackAllService.java
+++ b/src/main/java/kr/ac/sejong/service/TrackAllService.java
@@ -1,17 +1,20 @@
 package kr.ac.sejong.service;
 
+import kr.ac.sejong.domain.course.Course;
+import kr.ac.sejong.domain.rule.Rule;
+import kr.ac.sejong.domain.trackJudge.TrackJudge;
 import kr.ac.sejong.domain.trackcourse.TrackCourse;
 import kr.ac.sejong.domain.trackcourse.TrackCourseRepository;
 import kr.ac.sejong.web.dto.course.CourseResponseDto;
 import kr.ac.sejong.web.dto.trackcourse.TrackCourseDto;
 import kr.ac.sejong.web.dto.trackcourse.TrackCourseResponseDto;
+import kr.ac.sejong.web.dto.trackjudge.CourseStatisticDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.java.Log;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
@@ -19,10 +22,12 @@ import java.util.stream.Collectors;
 @Log
 public class TrackAllService {
     private final TrackCourseRepository trackCourseRepository;
+    private final TrackRuleService trackRuleService;
 
     @Transactional
-    public Map trackAllStatistic(Long univId){
-        List<TrackCourse> trackCourses = trackCourseRepository.findByUnivId(1L);
+    public Map<String, Map<String, List<CourseResponseDto>>> trackAllStatistic(Long univId){
+        List<TrackCourse> trackCourses = trackCourseRepository.findByUnivId(univId);
+        List<Rule> UnivRuleTypes = trackRuleService.findByUnivIdDistinct(univId);
 
         Map<String, Map<String, List<CourseResponseDto>>> trackAllStatistic = trackCourses.stream()
                 .collect(
@@ -37,6 +42,12 @@ public class TrackAllService {
                                 }))
                         )
                 );
+
+        trackAllStatistic.forEach((key, value) -> {
+            for (Rule ruleType : UnivRuleTypes) {
+                value.computeIfAbsent(ruleType.getCourseType().getText() , k -> Collections.emptyList());
+            }
+        });
 
         return trackAllStatistic;
     }

--- a/src/main/java/kr/ac/sejong/service/TrackRuleService.java
+++ b/src/main/java/kr/ac/sejong/service/TrackRuleService.java
@@ -30,4 +30,9 @@ public class TrackRuleService {
 
         return trackRule;
     }
+
+    @Transactional
+    public List<Rule> findByUnivIdDistinct(Long univId) {
+        return ruleRepository.findByUnivIdDistinct(univId);
+    }
 }

--- a/src/main/java/kr/ac/sejong/web/ApiTrackAllController.java
+++ b/src/main/java/kr/ac/sejong/web/ApiTrackAllController.java
@@ -1,12 +1,14 @@
 package kr.ac.sejong.web;
 
 import kr.ac.sejong.service.TrackAllService;
+import kr.ac.sejong.web.dto.course.CourseResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
 import java.util.Map;
 
 
@@ -18,7 +20,7 @@ public class ApiTrackAllController {
     private final TrackAllService trackAllService;
 
     @GetMapping("/{univId}")
-    public Map list(@PathVariable Long univId) {
+    public Map<String, Map<String, List<CourseResponseDto>>> list(@PathVariable Long univId) {
         return trackAllService.trackAllStatistic(univId);
     }
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -134,6 +134,13 @@ INSERT INTO track_course(id, courseType, courseId, trackId) VALUES (17, 'APPLIED
 INSERT INTO track_course(id, courseType, courseId, trackId) VALUES (18, 'APPLIED', 18, 2);
 INSERT INTO track_course(id, courseType, courseId, trackId) VALUES (19, 'APPLIED', 19, 2);
 
+INSERT INTO track_course(id, courseType, courseId, trackId) VALUES (20, 'APPLIED', 20, 3);
+INSERT INTO track_course(id, courseType, courseId, trackId) VALUES (21, 'APPLIED', 21, 3);
+INSERT INTO track_course(id, courseType, courseId, trackId) VALUES (22, 'APPLIED', 22, 3);
+INSERT INTO track_course(id, courseType, courseId, trackId) VALUES (23, 'APPLIED', 23, 3);
+INSERT INTO track_course(id, courseType, courseId, trackId) VALUES (24, 'APPLIED', 24, 3);
+INSERT INTO track_course(id, courseType, courseId, trackId) VALUES (25, 'APPLIED', 25, 3);
+
 -- Degree
 INSERT INTO degree(id, title) VALUES (1, '학사');
 INSERT INTO degree(id, title) VALUES (2, '석사');
@@ -146,8 +153,9 @@ INSERT INTO rule(id, credit, courseType, trackId, degreeId) VALUES (1, 9, 'BASIC
 INSERT INTO rule(id, credit, courseType, trackId, degreeId) VALUES (2, 18, 'APPLIED', 1, 1);
 
 INSERT INTO rule(id, credit, courseType, trackId, degreeId) VALUES (3, 9, 'BASIC', 2, 1);
-INSERT INTO rule(id, credit, courseType, trackId, degreeId) VALUES (4, 9, 'APPLIED', 2, 1);
-INSERT INTO rule(id, credit, courseType, trackId, degreeId) VALUES (5, 18, 'EXPERT', 2, 1);
+INSERT INTO rule(id, credit, courseType, trackId, degreeId) VALUES (4, 18, 'APPLIED', 2, 1);
+
+INSERT INTO rule(id, credit, courseType, trackId, degreeId) VALUES (5, 18, 'APPLIED', 3, 1);
 
 -- Member
 INSERT INTO member(id,userId, email, name, password,major, univ) VALUES (1,'student','k@h.com', '김학생', '{bcrypt}$2a$10$aI/58n6pbSK6r0uplO82Pe3QT7xiquclSXQXFrDjz3jD/FvGz3BRG','정치외교학과','소프트웨어융합대학');


### PR DESCRIPTION
@kimhanui @2kyung19 

기존 방식은 stream groupingby를 사용하여 트랙에 해당하는 규칙에 있는 CourseType만 반환함

변경전
만약 SW트랙-인공지능의 CourseType이 basic, applied면 -> basic, applied 출력
만약 SW트랙-사이버국방의 CourseType이 basic이면 -> basic만 출력

이처럼 trackRule에 있는 CourseType만 출력했지만 이렇게 하면 CourseType의 개수가 맞지 않아 테이블 컬럼이 틀어지는 오류 발생

따라서 대학에 속한 트랙의 CourseType을 먼저 계산한후에 그것에 맞추어 출력
(만약 값이 없으면 빈 컬렉션 반환)

변경후
대학에 속한 트랙의 CourseType을 먼저 계산(basic, applied) 계산된 목록을 통해 값 반환
만약 SW트랙-인공지능의 CourseType이 basic, applied면 -> basic, applied 출력
만약 SW트랙-사이버국방의 CourseType이 basic이면 -> basic, applied(빈 컬렉션) 출력

Resolves #196 