### PR TITLE
BUG : PercentColor에서 색상 반환시 경계 값(100%, 50%, 25%)이 항상 RED 색상이 반환되는 오류 수정

### DIFF
--- a/src/main/java/kr/ac/sejong/domain/trackJudge/PercentColorEnum.java
+++ b/src/main/java/kr/ac/sejong/domain/trackJudge/PercentColorEnum.java
@@ -31,8 +31,8 @@ public enum PercentColorEnum {
 
     public static PercentColorEnum percentToColor(Double percent){
         return Arrays.stream(PercentColorEnum.values())
-                .filter(percentColor -> percentColor.min < Long.valueOf(percent.longValue()))
-                .filter(percentColor -> percentColor.max > Long.valueOf(percent.longValue()))
+                .filter(percentColor -> percentColor.min <= Long.valueOf(percent.longValue()))
+                .filter(percentColor -> percentColor.max >= Long.valueOf(percent.longValue()))
                 .findAny()
                 .orElse(RED);
     }


### PR DESCRIPTION
@2kyung19 @kimhanui 범위를 포함하게 변경 

```java
.filter(percentColor -> percentColor.min <= Long.valueOf(percent.longValue()))
.filter(percentColor -> percentColor.max >= Long.valueOf(percent.longValue()))
```
Resolves #211 