### PR TITLE
[CLN,ENH,Help] members_judgelogs 테이블 잘못 생성, 로그 컨트롤러 작성

### DIFF
--- a/src/main/java/kr/ac/sejong/domain/member/Member.java
+++ b/src/main/java/kr/ac/sejong/domain/member/Member.java
@@ -40,7 +40,7 @@ public class Member {
 
     private LocalDateTime logoutTime;
 
-    @OneToMany(cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<JudgeLog> judgeLogs;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, fetch = FetchType.EAGER)

--- a/src/main/java/kr/ac/sejong/domain/trackJudge/JudgeLog/JudgeLogRepository.java
+++ b/src/main/java/kr/ac/sejong/domain/trackJudge/JudgeLog/JudgeLogRepository.java
@@ -4,7 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JudgeLogRepository extends JpaRepository<JudgeLog, Long>, JudgeLogCustomRepository {
 
-    public Long deleteByMember(String userId);
+    public Long deleteByMember_UserId(String userId);
 
-    public Long deleteByTrack(Long trackId);
+    public Long deleteByTrack_Id(Long trackId);
 }

--- a/src/main/java/kr/ac/sejong/domain/trackJudge/JudgeLog/JudgeLogRepositoryImpl.java
+++ b/src/main/java/kr/ac/sejong/domain/trackJudge/JudgeLog/JudgeLogRepositoryImpl.java
@@ -50,10 +50,4 @@ public class JudgeLogRepositoryImpl extends QuerydslRepositorySupport implements
                 .orderBy(judgeLog.id.desc())
                 .fetch();
     }
-
-//    @Override
-//    public Long saveWithTrackAndMember(String userId, Long trackid) {
-//        return null;
-//    }
-
 }

--- a/src/main/java/kr/ac/sejong/service/JudgeLogService.java
+++ b/src/main/java/kr/ac/sejong/service/JudgeLogService.java
@@ -6,9 +6,12 @@ import kr.ac.sejong.domain.track.Track;
 import kr.ac.sejong.domain.track.TrackRepository;
 import kr.ac.sejong.domain.trackJudge.JudgeLog.JudgeLog;
 import kr.ac.sejong.domain.trackJudge.JudgeLog.JudgeLogRepository;
-import kr.ac.sejong.web.dto.trackjudge.JudgeLogDto;
+import kr.ac.sejong.web.dto.trackjudge.JudgeLogRequestDto;
+import kr.ac.sejong.web.dto.trackjudge.JudgeLogResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.java.Log;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,7 +32,7 @@ public class JudgeLogService {
     private final TrackRepository trackRepository;
 
     @Transactional
-    public void updateOrInsert(JudgeLogDto dto) throws Exception {
+    public void updateOrInsert(JudgeLogRequestDto dto) throws Exception {
         Member member = memberRepository.findByUserId(dto.getUserId()).get();
         Track track = trackRepository.findById(dto.getTrackId()).get();
         Optional<JudgeLog> judgeLog = repo.findByMemberAndTrack(dto.getUserId(), dto.getTrackId());
@@ -46,34 +49,35 @@ public class JudgeLogService {
     }
 
     @Transactional(readOnly = true)
-    public List<JudgeLogDto> findByMember(String userId) throws Exception {
+    public List<JudgeLogResponseDto> findByMember(String userId) throws Exception {
         return repo.findAllByMember(userId).stream()
-                .map(JudgeLogDto::new)
+                .map(JudgeLogResponseDto::new)
                 .collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)
-    public List<JudgeLogDto> findByTrack(Long trackId) throws Exception {
+    public List<JudgeLogResponseDto> findByTrack(Long trackId) throws Exception {
         return repo.findAllByTrack(trackId).stream()
-                .map(JudgeLogDto::new)
+                .map(JudgeLogResponseDto::new)
                 .collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)
-    public List<JudgeLogDto> findAllByDesc() throws Exception {
+    public List<JudgeLogResponseDto> findAllByDesc() throws Exception {
         return repo.findAllByDesc().stream()
-                .map(JudgeLogDto::new)
+                .map(JudgeLogResponseDto::new)
                 .collect(Collectors.toList());  //페치 조인. 딜레이 길 수도.
     }
 
+    @Transactional
+    public ResponseEntity<String> deleteByMember(String userId) throws Exception{
+        repo.deleteByMember_UserId(userId);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
 
-//    @Transactional
-//    public void deleteByMember(Member member) throws Exception{
-//        repo.deleteByMember(member.getUserId());
-//    }
-//
-//    @Transactional
-//    public void deleteByTrack(Track track) throws Exception{
-//        repo.deleteByTrack(track.getId());
-//    }
+    @Transactional
+    public ResponseEntity<String> deleteByTrack(Long trackId) throws Exception{
+        repo.deleteByTrack_Id(trackId);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
 }

--- a/src/main/java/kr/ac/sejong/web/ApiJudgeLogController.java
+++ b/src/main/java/kr/ac/sejong/web/ApiJudgeLogController.java
@@ -20,19 +20,19 @@ public class ApiJudgeLogController {
 
     @PostMapping("/log/update")
     public ResponseEntity<String> update(@RequestBody JudgeLogRequestDto reqDto)throws Exception{
-        service.updateOrInsert(reqDto);    /**--> globalException으로 처리하는데 res entity는?**/
+        service.updateOrInsert(reqDto);
         ResponseEntity<String> entity = new ResponseEntity<>(HttpStatus.OK);
         return entity;
     }
 
-    @GetMapping("/log/find1/{userId}")
+    @GetMapping("/log/find/user/{userId}")
     public ResponseEntity<List<JudgeLogResponseDto>> find(@PathVariable String userId) throws Exception {
         List<JudgeLogResponseDto> resDtos = service.findByMember(userId);
         ResponseEntity<List<JudgeLogResponseDto>> entity = new ResponseEntity<>(resDtos, HttpStatus.OK);
         return entity;
     }
 
-    @GetMapping("/log/find2/{trackId}")
+    @GetMapping("/log/find/track/{trackId}")
     public ResponseEntity<List<JudgeLogResponseDto>> find(@PathVariable Long trackId) throws Exception {
         List<JudgeLogResponseDto> resDtos = service.findByTrack(trackId);
         ResponseEntity<List<JudgeLogResponseDto>> entity = new ResponseEntity<>(resDtos, HttpStatus.OK);

--- a/src/main/java/kr/ac/sejong/web/ApiJudgeLogController.java
+++ b/src/main/java/kr/ac/sejong/web/ApiJudgeLogController.java
@@ -1,0 +1,48 @@
+package kr.ac.sejong.web;
+
+import kr.ac.sejong.service.JudgeLogService;
+import kr.ac.sejong.web.dto.trackjudge.JudgeLogRequestDto;
+import kr.ac.sejong.web.dto.trackjudge.JudgeLogResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.java.Log;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Log
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/*")
+public class ApiJudgeLogController {
+    private final JudgeLogService service;
+
+    @PostMapping("/log/update")
+    public ResponseEntity<String> update(@RequestBody JudgeLogRequestDto reqDto)throws Exception{
+        service.updateOrInsert(reqDto);    /**--> globalException으로 처리하는데 res entity는?**/
+        ResponseEntity<String> entity = new ResponseEntity<>(HttpStatus.OK);
+        return entity;
+    }
+
+    @GetMapping("/log/find1/{userId}")
+    public ResponseEntity<List<JudgeLogResponseDto>> find(@PathVariable String userId) throws Exception {
+        List<JudgeLogResponseDto> resDtos = service.findByMember(userId);
+        ResponseEntity<List<JudgeLogResponseDto>> entity = new ResponseEntity<>(resDtos, HttpStatus.OK);
+        return entity;
+    }
+
+    @GetMapping("/log/find2/{trackId}")
+    public ResponseEntity<List<JudgeLogResponseDto>> find(@PathVariable Long trackId) throws Exception {
+        List<JudgeLogResponseDto> resDtos = service.findByTrack(trackId);
+        ResponseEntity<List<JudgeLogResponseDto>> entity = new ResponseEntity<>(resDtos, HttpStatus.OK);
+        return entity;
+    }
+
+    @GetMapping("/admin/log/find/all")
+    public ResponseEntity<List<JudgeLogResponseDto>> findAll() throws Exception {
+        List<JudgeLogResponseDto> resDtos = service.findAllByDesc();
+        ResponseEntity<List<JudgeLogResponseDto>> entity = new ResponseEntity<>(resDtos, HttpStatus.OK);
+        return entity;
+    }
+}

--- a/src/main/java/kr/ac/sejong/web/ApiTrackJudgeController.java
+++ b/src/main/java/kr/ac/sejong/web/ApiTrackJudgeController.java
@@ -1,9 +1,7 @@
 package kr.ac.sejong.web;
 
 import kr.ac.sejong.domain.course.Course;
-import kr.ac.sejong.domain.member.MemberRepository;
 import kr.ac.sejong.domain.rule.Rule;
-import kr.ac.sejong.domain.track.TrackRepository;
 import kr.ac.sejong.domain.trackcourse.TrackCourse;
 import kr.ac.sejong.service.JudgeLogService;
 import kr.ac.sejong.service.TrackCourseService;
@@ -11,7 +9,7 @@ import kr.ac.sejong.service.TrackJudgeService;
 import kr.ac.sejong.service.TrackRuleService;
 import kr.ac.sejong.web.dto.CustomUserDetails;
 import kr.ac.sejong.web.dto.excel.ReportCardExcelDto;
-import kr.ac.sejong.web.dto.trackjudge.JudgeLogDto;
+import kr.ac.sejong.web.dto.trackjudge.JudgeLogRequestDto;
 import kr.ac.sejong.web.dto.trackjudge.TrackStatistic;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.java.Log;
@@ -56,14 +54,14 @@ public class ApiTrackJudgeController {
         TrackStatistic trackStatistic = trackJudgeService.trackJudgeOne(trackRule, transcriptCourses, standardCourses);
 
         /** 판정 기록 **/
-        JudgeLogDto judgeLogDto = JudgeLogDto.builder()
+        JudgeLogRequestDto judgeLogRequestDto = JudgeLogRequestDto.builder()
                 .percent(trackStatistic.getPercent())
                 .pnp(trackStatistic.getPnp())
                 .userId(userModel.getUserId())
                 .trackId(trackId)
                 .build();
 
-        judgeLogService.updateOrInsert(judgeLogDto);
+        judgeLogService.updateOrInsert(judgeLogRequestDto);
 
         return trackStatistic;
     }

--- a/src/main/java/kr/ac/sejong/web/dto/trackjudge/JudgeLogRequestDto.java
+++ b/src/main/java/kr/ac/sejong/web/dto/trackjudge/JudgeLogRequestDto.java
@@ -1,0 +1,43 @@
+package kr.ac.sejong.web.dto.trackjudge;
+
+import kr.ac.sejong.domain.member.Member;
+import kr.ac.sejong.domain.track.Track;
+import kr.ac.sejong.domain.trackJudge.JudgeLog.JudgeLog;
+import kr.ac.sejong.domain.trackJudge.TrackJudge;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class JudgeLogRequestDto {
+
+    private Double percent;
+    private TrackJudge.PNP pnp;
+    private String userId;
+    private Long trackId;
+
+    public JudgeLog toEntity(Member member, Track track){
+        return JudgeLog.builder()
+                .member(member)
+                .track(track)
+                .percent(percent)
+                .pnp(pnp)
+                .build();
+    }
+
+    public JudgeLogRequestDto(JudgeLog judgeLog){
+        this.percent = judgeLog.getPercent();
+        this.pnp = judgeLog.getPnp();
+        this.userId = judgeLog.getMember().getUserId();
+        this.trackId = judgeLog.getTrack().getId();
+    }
+
+    @Builder
+    public JudgeLogRequestDto(Double percent, TrackJudge.PNP pnp, String userId, Long trackId) {
+        this.percent = percent;
+        this.pnp = pnp;
+        this.userId=userId;
+        this.trackId = trackId;
+    }
+}

--- a/src/main/java/kr/ac/sejong/web/dto/trackjudge/JudgeLogResponseDto.java
+++ b/src/main/java/kr/ac/sejong/web/dto/trackjudge/JudgeLogResponseDto.java
@@ -10,12 +10,14 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
 @Getter
-public class JudgeLogDto {
+public class JudgeLogResponseDto {
 
     private Double percent;
     private TrackJudge.PNP pnp;
     private String userId;
+    private String userName;
     private Long trackId;
+    private String trackName;
 
     public JudgeLog toEntity(Member member, Track track){
         return JudgeLog.builder()
@@ -26,17 +28,23 @@ public class JudgeLogDto {
                 .build();
     }
 
-    public JudgeLogDto(JudgeLog judgeLog){
+    public JudgeLogResponseDto(JudgeLog judgeLog){
         this.percent = judgeLog.getPercent();
         this.pnp = judgeLog.getPnp();
         this.userId = judgeLog.getMember().getUserId();
+        this.userName = judgeLog.getMember().getName();
         this.trackId = judgeLog.getTrack().getId();
+        this.trackName = judgeLog.getTrack().getTitle();
     }
+
     @Builder
-    public JudgeLogDto(Double percent, TrackJudge.PNP pnp, String userId, Long trackId) {
+    public JudgeLogResponseDto(Double percent, TrackJudge.PNP pnp, String userId,
+                               String userName, Long trackId, String trackName) {
         this.percent = percent;
         this.pnp = pnp;
         this.userId=userId;
+        this.userName=userName;
         this.trackId = trackId;
+        this.trackName = trackName;
     }
 }

--- a/src/test/java/kr/ac/sejong/JudgeLogTest.java
+++ b/src/test/java/kr/ac/sejong/JudgeLogTest.java
@@ -2,7 +2,8 @@ package kr.ac.sejong;
 
 import kr.ac.sejong.domain.trackJudge.TrackJudge;
 import kr.ac.sejong.service.JudgeLogService;
-import kr.ac.sejong.web.dto.trackjudge.JudgeLogDto;
+import kr.ac.sejong.web.dto.trackjudge.JudgeLogRequestDto;
+import kr.ac.sejong.web.dto.trackjudge.JudgeLogResponseDto;
 import lombok.extern.java.Log;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,64 +23,76 @@ public class JudgeLogTest {
     private JudgeLogService service;
 
     @Test
-    public void 로그_updateOrInsert() throws Exception {
-        JudgeLogDto dto = JudgeLogDto.builder()
+    public void 로그_update() throws Exception {
+        //given
+        JudgeLogRequestDto dto = JudgeLogRequestDto.builder()
                 .percent(70.0)
                 .pnp(TrackJudge.PNP.NON_PASS)
                 .userId("pro")
                 .trackId(1L)
                 .build();
-        JudgeLogDto dto2 = JudgeLogDto.builder()
+        JudgeLogRequestDto dto2 = JudgeLogRequestDto.builder()
                 .percent(40.0)
                 .pnp(TrackJudge.PNP.NON_PASS)
                 .userId("pro")
                 .trackId(1L)
                 .build();
 
+        //when
         service.updateOrInsert(dto);
         service.updateOrInsert(dto2);
     }
 
     @Test
-    public void 모든_로그_조회() {
-        List<JudgeLogDto> judgeLogDtos = null;
+    public void 모든_로그_조회() throws Exception {
         try {
-            judgeLogDtos = service.findAllByDesc();
+            service.findAllByDesc();
         } catch (Exception e) {
             e.printStackTrace();
         }
-        for (JudgeLogDto dto : judgeLogDtos) {
-            log.info("member: " + dto.getUserId()
-                    + " track: " + dto.getTrackId());
-        }
+        printAll();
     }
 
     @Test
-    public void 멤버에_의한_조회() {
-        List<JudgeLogDto> judgeLogDtos = null;
+    public void 멤버에_의한_조회() throws Exception {
         try {
-            judgeLogDtos = service.findByMember("student");
+            service.findByMember("student");
         } catch (Exception e) {
             e.printStackTrace();
         }
-        for (JudgeLogDto dto : judgeLogDtos) {
-            log.info("member: " + dto.getUserId()
-                    + " track: " + dto.getTrackId());
-        }
+        printAll();
     }
 
     @Test
     public void 트랙에_의한_조회() throws Exception {
-        List<JudgeLogDto> judgeLogDtos = null;
         try {
-            judgeLogDtos = service.findByTrack(1L);
+            service.findByTrack(1L);
         } catch (Exception e) {
             e.printStackTrace();
         }
-        for (JudgeLogDto dto : judgeLogDtos) {
-            log.info("member: " + dto.getUserId()
-                    + " track: " + dto.getTrackId());
-        }
+        printAll();
     }
 
+    @Test
+    public void deleteByMember() throws Exception {
+        String userId = "student";
+        service.deleteByMember(userId);
+        printAll();
+    }
+
+    @Test
+    public void deleteByTrack() throws Exception {
+        Long trackId = 1L;
+        service.deleteByTrack(trackId);
+
+        printAll();
+    }
+
+    public void printAll() throws Exception {
+        List<JudgeLogResponseDto> judgeLogDtos = service.findAllByDesc();
+        for (JudgeLogResponseDto dto : judgeLogDtos) {
+            log.info("member: " + dto.getUserId()
+                    + ", track: " + dto.getTrackId());
+        }
+    }
 }


### PR DESCRIPTION
[CLN]
- 원인 : member 연관관계 중 OneToMany인 judgeLogs에서 mappedBy = "member" 설정을 깜빡함 !

[ENH]
- judgeLog controller 작성(find: find url네이밍에 byMember나 byTrack들어가면 보안취약할 것 같아서 일단 1,2로 나눔)
- dto: 요청용, 응답용으로 분리

[Help]
- querydsl 삭제 배치쿼리..? 뭔지 잘 모르겠어서 jpaRepository로 delete 수행함. @riyenas0925 