### PR TITLE
ENH : 허용 용량을 넘어선 파일 첨부시 에러 발생 기능 구현

### DIFF
--- a/src/main/java/kr/ac/sejong/global/GlobalExceptionHandler.java
+++ b/src/main/java/kr/ac/sejong/global/GlobalExceptionHandler.java
@@ -3,18 +3,28 @@ package kr.ac.sejong.global;
 import kr.ac.sejong.global.exception.ErrorCode;
 import lombok.extern.java.Log;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.tomcat.util.http.fileupload.FileUploadBase;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
+import javax.naming.SizeLimitExceededException;
 import java.nio.file.AccessDeniedException;
 
 @ControllerAdvice
 @Log
 public class GlobalExceptionHandler {
+
+    /* Maximum upload size exceed Error*/
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    protected ResponseEntity<ErrorResponse> handleMaxUploadSizeExceedException(MaxUploadSizeExceededException e) {
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.MAX_UPLOAD_SIZE_EXCEEDED);
+        return new ResponseEntity<>(response, HttpStatus.valueOf(ErrorCode.MAX_UPLOAD_SIZE_EXCEEDED.getStatus()));
+    }
 
     /* @RequestBody, @RequestBody, @Validate Binding Error */
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/src/main/java/kr/ac/sejong/global/exception/ErrorCode.java
+++ b/src/main/java/kr/ac/sejong/global/exception/ErrorCode.java
@@ -8,7 +8,8 @@ public enum ErrorCode {
     ENTITY_NOT_FOUND(400, "C003", " Entity Not Found"),
     INTERNAL_SERVER_ERROR(500, "C004", "Server Error"),
     INVALID_TYPE_VALUE(400, "C005", " Invalid Type Value"),
-    HANDLE_ACCESS_DENIED(403, "C006", "Access is Denied");
+    HANDLE_ACCESS_DENIED(403, "C006", "Access is Denied"),
+    MAX_UPLOAD_SIZE_EXCEEDED(400, "C007", "Upload Size Exceeded");
 
     private final String code;
     private final String message;

--- a/src/main/resources/develop/application-h2.properties
+++ b/src/main/resources/develop/application-h2.properties
@@ -23,8 +23,9 @@ spring.datasource.initialization-mode=always
 spring.mvc.view.prefix=/WEB-INF/views/
 spring.mvc.view.suffix=.jsp
 
-spring.servlet.multipart.max-file-size=10MB
-spring.servlet.multipart.max-request-size=10MB
+spring.servlet.multipart.max-file-size=2MB
+spring.servlet.multipart.max-request-size=2MB
+server.tomcat.max-swallow-size=-1
 
 spring.devtools.livereload.enabled=true
 


### PR DESCRIPTION
@kimhanui 엑셀파일의 용량이 최대 2MB를 안넘을것 같아서 2MB 이상되는 파일첨부시 오류가 발생하도록 예외 처리 추가

![image](https://user-images.githubusercontent.com/32615702/81948897-31bf1800-963d-11ea-91ff-29a769a65725.png)
