### PR TITLE
ENH, CLN : TrackAll 리펙토링, 스프링 부트 캐시 적용, TrackCourse의 N+1 문제 해결

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,11 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-cache</artifactId>
+    </dependency>
+
     <!-- Spring Security -->
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/src/main/java/kr/ac/sejong/SejongtrackApplication.java
+++ b/src/main/java/kr/ac/sejong/SejongtrackApplication.java
@@ -2,7 +2,9 @@ package kr.ac.sejong;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
+@EnableCaching
 @SpringBootApplication
 public class SejongtrackApplication {
     public static void main(String[] args) {

--- a/src/main/java/kr/ac/sejong/domain/course/Course.java
+++ b/src/main/java/kr/ac/sejong/domain/course/Course.java
@@ -27,7 +27,7 @@ public class Course {
     @OneToMany(mappedBy = "course", cascade = CascadeType.ALL)
     List<TrackCourse> trackCourses;
 
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "courseScheduleId")
     CourseSchedule courseSchedule;
 

--- a/src/main/java/kr/ac/sejong/domain/trackcourse/TrackCourse.java
+++ b/src/main/java/kr/ac/sejong/domain/trackcourse/TrackCourse.java
@@ -20,11 +20,11 @@ public class TrackCourse {
     @Enumerated(EnumType.STRING)
     private Type courseType;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "trackId")
     Track track;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "courseId")
     Course course;
 

--- a/src/main/java/kr/ac/sejong/domain/trackcourse/TrackCourseRepositoryImpl.java
+++ b/src/main/java/kr/ac/sejong/domain/trackcourse/TrackCourseRepositoryImpl.java
@@ -1,5 +1,7 @@
 package kr.ac.sejong.domain.trackcourse;
 
+import kr.ac.sejong.domain.course.QCourse;
+import kr.ac.sejong.domain.track.QTrack;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
 
 import java.util.List;
@@ -13,7 +15,12 @@ public class TrackCourseRepositoryImpl extends QuerydslRepositorySupport impleme
     @Override
     public List<TrackCourse> findByTrackId(Long trackId) {
         final QTrackCourse trackCourse = QTrackCourse.trackCourse;
+        final QTrack track = QTrack.track;
+        final QCourse course = QCourse.course;
+
         return from(trackCourse)
+                .join(trackCourse.track, track).fetchJoin()
+                .join(trackCourse.course, course).fetchJoin()
                 .where(trackCourse.track.id.eq(trackId))
                 .fetch();
     }
@@ -21,7 +28,12 @@ public class TrackCourseRepositoryImpl extends QuerydslRepositorySupport impleme
     @Override
     public List<TrackCourse> findByUnivId(Long univId) {
         final QTrackCourse trackCourse = QTrackCourse.trackCourse;
+        final QTrack track = QTrack.track;
+        final QCourse course = QCourse.course;
+
         return from(trackCourse)
+                .join(trackCourse.track, track).fetchJoin()
+                .join(trackCourse.course, course).fetchJoin()
                 .where(trackCourse.track.univ.id.eq(univId))
                 .fetch();
     }

--- a/src/main/java/kr/ac/sejong/service/TrackAllService.java
+++ b/src/main/java/kr/ac/sejong/service/TrackAllService.java
@@ -1,32 +1,31 @@
 package kr.ac.sejong.service;
 
-import kr.ac.sejong.domain.course.Course;
 import kr.ac.sejong.domain.rule.Rule;
-import kr.ac.sejong.domain.trackJudge.TrackJudge;
+import kr.ac.sejong.domain.rule.RuleRepository;
 import kr.ac.sejong.domain.trackcourse.TrackCourse;
 import kr.ac.sejong.domain.trackcourse.TrackCourseRepository;
 import kr.ac.sejong.web.dto.course.CourseResponseDto;
-import kr.ac.sejong.web.dto.trackcourse.TrackCourseDto;
-import kr.ac.sejong.web.dto.trackcourse.TrackCourseResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.java.Log;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
+@Log
 @RequiredArgsConstructor
 @Service
-@Log
 public class TrackAllService {
     private final TrackCourseRepository trackCourseRepository;
-    private final TrackRuleService trackRuleService;
+    private final RuleRepository trackRuleRepository;
 
+    @Cacheable(value = "trackAll", key = "#univId")
     @Transactional
     public Map<String, Map<String, List<CourseResponseDto>>> trackAllStatistic(Long univId){
         List<TrackCourse> trackCourses = trackCourseRepository.findByUnivId(univId);
-        List<Rule> UnivRuleTypes = trackRuleService.findByUnivIdDistinct(univId);
+        List<Rule> univRuleTypes = trackRuleRepository.findByUnivIdDistinct(univId);
 
         Map<String, Map<String, List<CourseResponseDto>>> trackAllStatistic = trackCourses.stream()
                 .collect(
@@ -43,7 +42,7 @@ public class TrackAllService {
                 );
 
         trackAllStatistic.forEach((key, value) -> {
-            for (Rule ruleType : UnivRuleTypes) {
+            for (Rule ruleType : univRuleTypes) {
                 value.computeIfAbsent(ruleType.getCourseType().getText() , k -> Collections.emptyList());
             }
         });

--- a/src/main/java/kr/ac/sejong/service/TrackRuleService.java
+++ b/src/main/java/kr/ac/sejong/service/TrackRuleService.java
@@ -53,9 +53,4 @@ public class TrackRuleService {
 
         return trackRule;
     }
-
-    @Transactional
-    public List<Rule> findByUnivIdDistinct(Long univId) {
-        return ruleRepository.findByUnivIdDistinct(univId);
-    }
 }


### PR DESCRIPTION
@kimhanui @2kyung19 
## Spring Boot Cache 사용
TrackAll 같은 경우에는 같은 데이터를 여러명이 반복해서 조회하기 때문에 매번 데이터베이스에서 꺼내 계산하는 것 보다 스프링 부트 캐시를 사용해서 한번 꺼내서 계산하고 TrackCourse가 변경되기 전까지는 이미 계산된 값을 캐시에서 꺼내서 사용하는 방식으로 변경 했음

### Test
-> 1차 조회 -> 160ms
-> 2차 조회 -> 10ms
-> 3차 조회 -> 11ms

처음 조회 할때만 계산때문에 오래걸리고 그뒤로는 캐시에 저장된 값을 꺼내기 때문에 시간이 단축됨

## N+1 문제
TrackCourse에서 N+1 문제가 발생하길래 QueryDsl에서 fetchjoin을 사용해서 해결